### PR TITLE
add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+CMakeCache.txt
+CMakeFiles/
+Makefile
+cmake_install.cmake
+libprotothread.*
+protothread.pc
+pttest

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ cmake_install.cmake
 libprotothread.*
 protothread.pc
 pttest
+install_manifest.txt


### PR DESCRIPTION
This makes `git status` output more meaningful by eliminating the reporting of expected files as being untracked.